### PR TITLE
RSpec sane defaults

### DIFF
--- a/spec/prezzo/calculator_spec.rb
+++ b/spec/prezzo/calculator_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe Prezzo::Calculator do
         before do
           class FooCalculator
             include Prezzo::Calculator
+
+            remove_method :calculate
           end
         end
 

--- a/spec/prezzo/calculator_spec.rb
+++ b/spec/prezzo/calculator_spec.rb
@@ -8,7 +8,7 @@ class DefaultCalculator
   end
 end
 
-describe Prezzo::Calculator do
+RSpec.describe Prezzo::Calculator do
   describe "context validation" do
     let(:default_context) { nil }
     let(:calculator) { DefaultCalculator.new(default_context) }

--- a/spec/prezzo/calculator_spec.rb
+++ b/spec/prezzo/calculator_spec.rb
@@ -8,6 +8,18 @@ class DefaultCalculator
   end
 end
 
+class DefinedCalculator
+  include Prezzo::Calculator
+
+  def calculate
+    10
+  end
+end
+
+class UndefinedCalculator
+  include Prezzo::Calculator
+end
+
 RSpec.describe Prezzo::Calculator do
   describe "context validation" do
     let(:default_context) { nil }
@@ -56,16 +68,8 @@ RSpec.describe Prezzo::Calculator do
 
   describe "calculate" do
     context "when a class inherits from calculator" do
-      let(:calculator) { FooCalculator.new }
-
       context "and the calculate is not implemented" do
-        before do
-          class FooCalculator
-            include Prezzo::Calculator
-
-            remove_method :calculate
-          end
-        end
+        let(:calculator) { UndefinedCalculator.new }
 
         it "raises an error" do
           expect { calculator.calculate }.to raise_error("Calculate not implemented")
@@ -73,17 +77,9 @@ RSpec.describe Prezzo::Calculator do
       end
 
       context "and the calculate is implemented" do
+        let(:calculator) { DefinedCalculator.new }
+
         context "when there are not context options" do
-          before do
-            class FooCalculator
-              include Prezzo::Calculator
-
-              def calculate
-                10
-              end
-            end
-          end
-
           it "returns the expected value" do
             expect(calculator.calculate).to eq(10)
           end

--- a/spec/prezzo/composable_spec.rb
+++ b/spec/prezzo/composable_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Prezzo::Composable do
+RSpec.describe Prezzo::Composable do
   let(:foo_calculator_instance) { double(:calculator, calculate: 10.0) }
   let(:bar_calculator_instance) { double(:calculator, calculate: 15.3) }
   let(:foo_calculator_class) do

--- a/spec/prezzo/context_spec.rb
+++ b/spec/prezzo/context_spec.rb
@@ -10,7 +10,7 @@ class FooContext
   end
 end
 
-describe Prezzo::Context do
+RSpec.describe Prezzo::Context do
   describe "validations" do
     context "when the data is valid" do
       let(:valid_context) do

--- a/spec/prezzo/explainable_spec.rb
+++ b/spec/prezzo/explainable_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Prezzo::Explainable do
+RSpec.describe Prezzo::Explainable do
   let(:foo_calculator_instance) { double(:calculator, calculate: 10.0) }
   let(:bar_calculator_instance) { double(:calculator, calculate: 15.3) }
   let(:foo_calculator_class) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,4 +4,10 @@ SimpleCov.start
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "prezzo"
 
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+  config.order = :random
+  Kernel.srand config.seed
+end
+
 RSpec::Expectations.configuration.on_potential_false_positives = :nothing


### PR DESCRIPTION
This MR updates RSpec configuration to disable monkey patching and runs the specs in random order

**Note** Interesting thing I found was that classes defined in before blocks leak into other tests; so had to remove_method calculate in order to make the tests pass