### PR TITLE
feature: Use multiline explain_with

### DIFF
--- a/lib/prezzo/explainable.rb
+++ b/lib/prezzo/explainable.rb
@@ -8,26 +8,33 @@ module Prezzo
 
     module ClassMethods
       def explain_with(*component_names)
-        define_method(:explain) do
-          explanation = {
-            total: calculate,
-          }
-
-          components = component_names.each_with_object({}) do |component, acc|
-            value = send(component)
-            if self.class.respond_to?(:components) && self.class.components.include?(component)
-              value = cached_components[component]
-            end
-            value = value.explain if value.respond_to?(:explain)
-            value = value.calculate if value.respond_to?(:calculate)
-            acc[component] = value
-          end
-
-          explanation[:components] = components unless components.empty?
-
-          explanation
-        end
+        @explained_component_names ||= []
+        @explained_component_names += component_names
       end
+
+      attr_reader :explained_component_names
+    end
+
+    def explain
+      component_names = self.class.explained_component_names || []
+
+      explanation = {
+        total: calculate,
+      }
+
+      components = component_names.each_with_object({}) do |component, acc|
+        value = send(component)
+        if self.class.respond_to?(:components) && self.class.components.include?(component)
+          value = cached_components[component]
+        end
+        value = value.explain if value.respond_to?(:explain)
+        value = value.calculate if value.respond_to?(:calculate)
+        acc[component] = value
+      end
+
+      explanation[:components] = components unless components.empty?
+
+      explanation
     end
   end
 end

--- a/spec/prezzo/explainable_spec.rb
+++ b/spec/prezzo/explainable_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Prezzo::Explainable do
         foo + 5.3
       end
     end
+
     class ExplainedCalculator
       include Prezzo::Calculator
       include Prezzo::Composable
@@ -31,7 +32,8 @@ RSpec.describe Prezzo::Explainable do
       composed_by foo: FooCalculator,
                   bar: BarCalculator
 
-      explain_with :foo, :bar, :other
+      explain_with :foo, :bar
+      explain_with :other
 
       def calculate
         foo + bar


### PR DESCRIPTION
This MR allows to call `explain_with` several times and split declaration in multi lines.

```ruby
  class ExplainedCalculator
      include Prezzo::Calculator
      include Prezzo::Composable
      include Prezzo::Explainable

      composed_by foo: FooCalculator,
                  bar: BarCalculator

      explain_with :foo, :bar
      explain_with :other

      def calculate
        foo + bar
      end

      private

      def other
        5
      end
  end
```