### PR TITLE
feature: Explain with verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,84 @@ Uber::RidePriceCalculator.new(context).explain
 #=> { total: 25.6, components: { base_fare: 4.3, price_per_distance: 21.3 } }
 ```
 
+#### Multiline `explain_with`
+
+`explain_with` can be splitted into several lines.
+
+```ruby
+class RidePriceCalculator
+  include Prezzo::Explainable
+
+  explain_with :base_fare
+  explain_with :price_per_distance
+end
+```
+
+#### ` explain_with` with the `resursive: false` option
+
+```ruby
+class FooCalculator
+  include Prezzo::Calculator
+  include Prezzo::Explainable
+
+  explain_with :bar, :baz
+
+  def calculate
+    bar + baz
+  end
+
+  def bar
+    10
+  end
+
+  def baz
+    20
+  end
+end
+
+class QuxCalculator
+  include Prezzo::Calculator
+  include Prezzo::Composable
+  include Prezzo::Explainable
+
+  composed_by foo: FooCalculator
+
+  explain_with :foo, resursive: false
+
+  def calculate
+    foo + 5
+  end
+end
+```
+
+`QuxCalculator#explain` now produces
+
+```ruby
+{
+  total: 35,
+  components: {
+    foo: 30
+  }
+}
+```
+
+but not
+
+```ruby
+{
+  total: 35,
+  components: {
+    foo: {
+      total: 30,
+      components: {
+        bar: 10,
+        baz: 20
+      }
+    }
+  }
+}
+```
+
 Check the full [Uber pricing](/spec/integration/uber_pricing_spec.rb) for more complete example with many calculators and factors.
 
 ## Development

--- a/lib/prezzo/explainable.rb
+++ b/lib/prezzo/explainable.rb
@@ -7,32 +7,33 @@ module Prezzo
     end
 
     module ClassMethods
-      def explain_with(*component_names)
-        @explained_component_names ||= []
-        @explained_component_names += component_names
+      def explain_with(*component_names, **options)
+        @explained_components ||= {}
+        component_names.each do |component_name|
+          @explained_components[component_name] = options
+        end
       end
 
-      attr_reader :explained_component_names
+      attr_reader :explained_components
     end
 
     def explain
-      component_names = self.class.explained_component_names || []
+      explained_components = self.class.explained_components || {}
 
       explanation = {
         total: calculate,
+        components: {},
       }
 
-      components = component_names.each_with_object({}) do |component, acc|
+      explained_components.each do |component, options|
         value = send(component)
         if self.class.respond_to?(:components) && self.class.components.include?(component)
           value = cached_components[component]
         end
-        value = value.explain if value.respond_to?(:explain)
+        value = value.explain if value.respond_to?(:explain) && options.fetch(:resursive, true)
         value = value.calculate if value.respond_to?(:calculate)
-        acc[component] = value
+        explanation[:components][component] = value
       end
-
-      explanation[:components] = components unless components.empty?
 
       explanation
     end

--- a/spec/prezzo/explainable_spec.rb
+++ b/spec/prezzo/explainable_spec.rb
@@ -56,20 +56,48 @@ RSpec.describe Prezzo::Explainable do
   end
 
   describe "explain" do
-    it "returns the expected value" do
-      expect(subject.explain).to eq(
-        total: 25.3,
-        components: {
-          foo: 10.0,
-          bar: {
-            total: 15.3,
-            components: {
-              foo: 10.0,
+    context "when resursive is not given" do
+      before do
+        class ExplainedCalculator
+          explain_with :foo, :bar
+          explain_with :other
+        end
+      end
+
+      it "returns the expected value" do
+        expect(subject.explain).to eq(
+          total: 25.3,
+          components: {
+            foo: 10.0,
+            bar: {
+              total: 15.3,
+              components: {
+                foo: 10.0,
+              },
             },
+            other: 5,
           },
-          other: 5,
-        },
-      )
+        )
+      end
+    end
+
+    context "when resursive = false is given" do
+      before do
+        class ExplainedCalculator
+          explain_with :foo, :bar, :other, resursive: false
+        end
+      end
+
+      it "returns the expected value" do
+        expect(subject.explain).to eq(
+          total: 25.3,
+          components: {
+            foo: 10.0,
+            bar: 15.3,
+            other: 5,
+          },
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Depends on https://github.com/marceloboeira/prezzo/pull/24

This MR allows to explain a composing calculator as a value, not as a hash

`{ total: ..., components: {...} }`.

Given

```ruby
class FooCalculator
  include Prezzo::Calculator
  include Prezzo::Explainable

  explain_with :bar, :baz

  def calculate
    bar + baz
  end

  def bar
    10
  end

  def baz
    20
  end
end

class QuxCalculator
  include Prezzo::Calculator
  include Prezzo::Composable
  include Prezzo::Explainable

  composed_by foo: FooCalculator

  explain_with :foo, resursive: false

  def calculate
    foo + 5
  end
end
```

`QuxCalculator#explain` now produces

```ruby
{
  total: 35,
  components: {
    foo: 30
  }
}
```

but not

```ruby
{
  total: 35,
  components: {
    foo: {
      total: 30,
      components: {
        bar: 10,
        baz: 20
      }
    }
  }
}
```