### PR TITLE
fix: Rename resursive to recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ class RidePriceCalculator
 end
 ```
 
-#### ` explain_with` with the `resursive: false` option
+#### ` explain_with` with the `recursive: false` option
 
 ```ruby
 class FooCalculator
@@ -195,7 +195,7 @@ class QuxCalculator
 
   composed_by foo: FooCalculator
 
-  explain_with :foo, resursive: false
+  explain_with :foo, recursive: false
 
   def calculate
     foo + 5

--- a/lib/prezzo/explainable.rb
+++ b/lib/prezzo/explainable.rb
@@ -30,7 +30,7 @@ module Prezzo
         if self.class.respond_to?(:components) && self.class.components.include?(component)
           value = cached_components[component]
         end
-        value = value.explain if value.respond_to?(:explain) && options.fetch(:resursive, true)
+        value = value.explain if value.respond_to?(:explain) && options.fetch(:recursive, true)
         value = value.calculate if value.respond_to?(:calculate)
         explanation[:components][component] = value
       end

--- a/spec/prezzo/explainable_spec.rb
+++ b/spec/prezzo/explainable_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Prezzo::Explainable do
   end
 
   describe "explain" do
-    context "when resursive is not given" do
+    context "when recursive is not given" do
       before do
         class ExplainedCalculator
           explain_with :foo, :bar
@@ -81,10 +81,10 @@ RSpec.describe Prezzo::Explainable do
       end
     end
 
-    context "when resursive = false is given" do
+    context "when recursive = false is given" do
       before do
         class ExplainedCalculator
-          explain_with :foo, :bar, :other, resursive: false
+          explain_with :foo, :bar, :other, recursive: false
         end
       end
 


### PR DESCRIPTION
Fix misspelling in `resursive` => `recursive`